### PR TITLE
docs: expand project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,46 @@
-# Welcome to your Expo app 👋
+# Rainbow Routine
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+Rainbow Routine is an early-stage Augmentative and Alternative Communication (AAC) app built with Expo and React Native. It focuses on fast, customizable communication through symbol grids, text entry, and routine building.
 
-## Get started
+![Splash screen](assets/images/splash.png)
 
-1. Install dependencies
+## Architecture Overview
+- **Navigation:** Expo Router with screens located under the `app` directory.
+- **UI Components:** Reusable UI in `components` and shared constants in `constants`.
+- **Styling:** [NativeWind](https://www.nativewind.dev/) for Tailwind-like classes.
+- **Animation & Validation:** React Native Reanimated animations and schema validation with [Zod](https://zod.dev/).
 
+## Environment Setup
+1. Ensure you have Node.js 18+ and npm installed.
+2. Install dependencies:
    ```bash
    npm install
    ```
-
-2. Start the app
-
+3. Start the development server:
    ```bash
-    npx expo start
+   npx expo start
    ```
 
-[ ] detailed card tab
-[ ] grid tab
-[ ] search grid
-[ ] store
-[ ] card list
-[ ] routine flow tab
-[ ] daily routine items collection
-[ ] multi language
-[ ] error boundary
-[ ] zod
-[ ] react query - cache management
+### Linting & Type Checks
+```bash
+npm run lint
+npm run ts:check
+```
+
+### Building
+Use [EAS Build](https://docs.expo.dev/eas/) for production binaries:
+```bash
+eas build
+```
+
+## Environment Variables
+- `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` – required to enable Clerk authentication (optional; currently commented out in code).
+
+## Roadmap
+- Detailed card tab for symbol-based communication
+- Grid navigation with search
+- Asset store and card list management
+- Routine flow tab for daily schedules
+- Multilingual support
+- Error boundaries and enhanced validation with Zod
+- React Query for caching and data management

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,0 +1,109 @@
+# Rainbow Routine Whitepaper
+
+## One-liner
+Rainbow Routine is an Augmentative and Alternative Communication (AAC) app offering symbol grids, quick phrases, and text entry. It is fully customizable, supports multiple input methods, text‑to‑speech, cloud sync, and multilingual interfaces.
+
+## Goals
+- Provide fast, low-friction communication.
+- Enable editable and shareable page sets across devices.
+- First-class accessibility and offline functionality.
+- Native assistant integration (Siri/App Intents, Android App Actions).
+- Privacy-first design with enterprise-grade sync.
+
+## Navigation & Flow
+- Onboarding: choose page set, access method, language/voice, optional sync login.
+- App shell: bottom tabs with per-tab stack navigation.
+- Core words: color-coded grid with persistent message bar.
+- Quick phrases, topics with word lists and categories, keyboard with word prediction.
+- Dashboard for editing, access settings, schedules, sync.
+- Search bar for instant word/page lookups.
+- Edit mode with drag-and-drop and import/export.
+- Scan mode overlays for switch/eye-gaze access.
+- Deep links and shortcuts.
+
+## Feature Set
+- Page sets: Core First, Motor Plan, Text, Scanning, Aphasia.
+- Symbol and text modes.
+- Multiple access methods: touch, switch, scanning, eye-gaze.
+- Behavioral supports: schedules, timers, scripts.
+- Cloud sync and sharing with roles.
+- Multilingual interface and TTS.
+- Assistant integrations.
+
+*Repository status: project scaffolding is in place; features above are under active development.*
+
+## Architecture
+- **App Layer:** Expo managed workflow with Expo Router.
+- **UI:** NativeWind, Reanimated, Gesture Handler, FlashList for grids, SVG symbols.
+- **State:** lightweight UI store plus server cache layer (planned).
+- **Data:** local-first database with conflict-aware sync (planned).
+- **I/O:** TTS, haptics, file system access, background tasks.
+- **Access Abstraction:** unified input adapter for touch, switch, scanning, eye-gaze.
+- **Security:** per-user keys for end-to-end encrypted shares.
+- **Testing/CI:** unit, accessibility, E2E tests; EAS builds and OTA updates.
+
+## Data Model (high level)
+```
+User { id, locale, voices[], accessPrefs, shareKeys }
+PageSet { id, name, type, locale, theme, gridSpec }
+Page { id, pageSetId, title, rows, cols, scanConfig }
+Button { id, pageId, label, symbolRef, action, phraseText, color, a11yHints }
+Symbol { id, pack, key, uri, altText }
+Schedule { id, steps[], alarms }
+Share { pageSetId, members[], role }
+```
+Telemetry is opt-in and redacted.
+
+## Accessibility Checklist
+- Focusable cells and large targets.
+- High-contrast and color-blind friendly themes.
+- Screen reader labels and haptic/audio cues.
+- Scan mode timing curves and switch mapping.
+- Eye-gaze dwell timers and adjustable key repeat.
+
+## Tech Stack Options
+- React Native (Expo).
+- Navigation via Expo Router.
+- NativeWind for styling.
+- FlashList for large grids.
+- State management via Zustand/Jotai/Redux Toolkit (to be decided).
+- Server cache via TanStack Query or RTK Query.
+- Local data via expo-sqlite, WatermelonDB, or Realm.
+- Backend options: Firebase, Supabase, Hasura, Appwrite, or AWS Amplify.
+- Auth via Firebase Auth, Supabase Auth, Cognito, or OIDC providers.
+- Symbol assets via CDN with pluggable packs.
+- TTS via expo-speech or platform TTS.
+- Monitoring via Sentry/Bugsnag; analytics via Amplitude/Mixpanel/PostHog.
+- Testing with Jest, Detox/Maestro, accessibility checks via axe-core.
+- CI/CD through EAS Build and Expo Updates.
+
+## Performance Targets
+- Cold start to first utterance <2s on mid-range devices.
+- Grid rendering under 16ms/frame with symbol caching.
+- Lazy-load heavy assets and virtualize lists.
+
+## Privacy & Compliance
+- Opt-in telemetry; no utterance content sent by default.
+- End-to-end encryption for shared page sets.
+- Data residency toggle; support for GDPR/LGPD/COPPA/FERPA.
+
+## Success Metrics
+- Time to first spoken phrase.
+- Setup time to first customized page set.
+- Crash-free users percentage.
+- TTS latency and offline reliability.
+- Accessibility audit pass rates.
+
+## Risks & Mitigations
+- Eye-gaze variability: abstracted input adapter, dwell fallback, vendor SDK isolation.
+- Symbol licensing: ship open set, licensed packs via keys.
+- Sync conflicts: optimistic UI with reconciliation or CRDT.
+- Performance on low-end devices: asset downscaling and caching, optional "lite" theme.
+- Vendor lock-in: backend repository pattern for swappable services.
+
+## Roadmap
+1. **MVP:** core words, quick phrases, topics, keyboard, TTS, local edit/save, high-contrast themes.
+2. **Sync & Share:** accounts, backups, caregiver roles, import/export.
+3. **Access Features:** scan mode, switch control, assistant integrations.
+4. **Eye-Gaze & Behavioral Supports:** schedules, timers, scripts.
+5. **AI Assist (opt-in):** translation workflow, smart phrase suggestions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,20 @@
+# Architecture
+
+## Directory Structure
+- **app/** – screen entries managed by Expo Router.
+- **components/** – reusable UI such as `SplashScreen`, `RoutineList`, and list items.
+- **hooks/** – custom hooks including `useLetterAnimation` for animated splash text.
+- **constants/** – shared constants like `RAINBOW_COLORS`.
+
+## Technologies
+- [Expo](https://expo.dev) and React Native.
+- [Expo Router](https://expo.github.io/router/docs) for file-based navigation.
+- [NativeWind](https://www.nativewind.dev/) for Tailwind-style styling.
+- [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/) for animations.
+- [Zod](https://zod.dev/) for runtime validation in components.
+
+## Data Flow
+The current prototype uses static placeholder data. Future work will introduce a local-first database with conflict-aware sync and cloud sharing.
+
+## Build & Deployment
+Run the development server with `npx expo start` and build production binaries through [EAS Build](https://docs.expo.dev/eas/).


### PR DESCRIPTION
## Summary
- enhance README with project description, architecture overview, setup instructions, and roadmap
- add comprehensive whitepaper outlining goals, features, and architecture
- document current project layout and technologies in docs/ARCHITECTURE.md

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_6895de5a68b48330872e73037705ecfc