### PR TITLE
Add project metadata to package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) 2024 Raniro Coelho <ranirocoelho@gmail.com>
+
+All rights reserved.
+
+This software and associated documentation files (the "Software") are proprietary and confidential. 
+You may not copy, modify, distribute, or sublicense the Software unless expressly authorized under a 
+separate written agreement with the copyright holder.
+
+For commercial licensing, support, or other inquiries, contact ranirocoelho@gmail.com.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,16 @@
 {
-  "name": "my-app",
+  "name": "rainbow-routine",
   "version": "1.0.0",
+  "description": "Cross-platform app for managing color-coded daily routines",
+  "author": {
+    "name": "Raniro Coelho",
+    "email": "ranirocoelho@gmail.com"
+  },
+  "license": "SEE LICENSE IN LICENSE",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ranirocoelho/rainbow-routine"
+  },
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- refine package.json metadata with structured author and repository
- mark package as SEE LICENSE IN LICENSE for proprietary distribution
- add LICENSE file with commercial terms for SaaS app

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_6895e2d62234833085bd373ac9f6c87d