### PR TITLE
Add MIT license and update package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,21 @@
-Copyright (c) 2024 Raniro Coelho <ranirocoelho@gmail.com>
+MIT License
 
-All rights reserved.
+Copyright (c) 2024 Raniro Coelho
 
-This software and associated documentation files (the "Software") are proprietary and confidential. 
-You may not copy, modify, distribute, or sublicense the Software unless expressly authorized under a 
-separate written agreement with the copyright holder.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-For commercial licensing, support, or other inquiries, contact ranirocoelho@gmail.com.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Raniro Coelho",
     "email": "ranirocoelho@gmail.com"
   },
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ranirocoelho/rainbow-routine"


### PR DESCRIPTION
## Summary
- replace proprietary license with MIT license
- update package.json license field to MIT

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895e8467a8c8330940973ee85e90717