### PR TITLE
feat: add optional auth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ eas build
 
 ## Environment Variables
 
-- `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` – required to enable Clerk authentication (optional; currently commented out in code).
+- `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` – Clerk publishable key when using Clerk authentication.
+- `EXPO_PUBLIC_USE_CLERK` – set to `true` to enable Clerk; otherwise a local stub auth will be used.
 
 ## Roadmap
 

--- a/src/app/(auth)/login/index.tsx
+++ b/src/app/(auth)/login/index.tsx
@@ -2,14 +2,25 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import React from 'react';
 import { Pressable, Text, View } from 'react-native';
+import { useOAuth } from '@/auth/provider';
 
 const LoginScreen = () => {
   const router = useRouter();
+  const { startOAuthFlow: startGoogleOAuthFlow } = useOAuth({
+    strategy: 'oauth_google',
+  });
+  const { startOAuthFlow: startAppleOAuthFlow } = useOAuth({
+    strategy: 'oauth_apple',
+  });
 
   const onOAuthPress = React.useCallback(
-    (provider: string) => {
-      console.log(`Simulating ${provider} login`);
-      router.replace('/(tabs)');
+    async (
+      startOAuthFlow: () => Promise<{ createdSessionId: string | null }>
+    ) => {
+      const { createdSessionId } = await startOAuthFlow();
+      if (createdSessionId) {
+        router.replace('/(tabs)');
+      }
     },
     [router]
   );
@@ -19,7 +30,7 @@ const LoginScreen = () => {
       <Text className='text-3xl mb-8 font-bold text-gray-800'>Welcome</Text>
 
       <Pressable
-        onPress={() => onOAuthPress('Google')}
+        onPress={() => onOAuthPress(startGoogleOAuthFlow)}
         className='bg-white px-8 py-3 rounded-full shadow-md mb-4 w-72 flex-row items-center'>
         <View className='flex-1 flex-row items-center justify-between px-2'>
           <Text className='text-black font-semibold text-lg'>
@@ -30,7 +41,7 @@ const LoginScreen = () => {
       </Pressable>
 
       <Pressable
-        onPress={() => onOAuthPress('Apple')}
+        onPress={() => onOAuthPress(startAppleOAuthFlow)}
         className='bg-black px-8 py-3 rounded-full shadow-md w-72 flex-row items-center'>
         <View className='flex-1 flex-row items-center justify-between px-2'>
           <Text className='text-white font-semibold text-lg'>
@@ -44,71 +55,3 @@ const LoginScreen = () => {
 };
 
 export default LoginScreen;
-
-// Original Clerk-based code (commented out)
-/*
-import { useOAuth } from '@clerk/clerk-expo'
-import * as Linking from 'expo-linking'
-import { useRouter } from 'expo-router'
-import * as WebBrowser from 'expo-web-browser'
-import React from 'react'
-import { Pressable, Text, View } from 'react-native'
-
-export const useWarmUpBrowser = () => {
-  React.useEffect(() => {
-    void WebBrowser.warmUpAsync()
-    return () => {
-      void WebBrowser.coolDownAsync()
-    }
-  }, [])
-}
-
-WebBrowser.maybeCompleteAuthSession()
-
-const LoginScreen = () => {
-  useWarmUpBrowser()
-  const router = useRouter()
-
-  const { startOAuthFlow: startGoogleOAuthFlow } = useOAuth({ strategy: 'oauth_google' })
-  const { startOAuthFlow: startAppleOAuthFlow } = useOAuth({ strategy: 'oauth_apple' })
-
-  const onOAuthPress = React.useCallback(async (startOAuthFlow: typeof startGoogleOAuthFlow) => {
-    try {
-      const { createdSessionId, signIn, signUp, setActive } = await startOAuthFlow({
-        redirectUrl: Linking.createURL('/(tabs)', { scheme: 'your-app-scheme' }),
-      })
-
-      if (createdSessionId) {
-        setActive!({ session: createdSessionId })
-        router.push('/(tabs)')
-      } else {
-        // Use signIn or signUp for next steps such as MFA
-      }
-    } catch (err) {
-      console.error('OAuth error', err)
-    }
-  }, [router])
-
-  return (
-    <View className="flex-1 items-center justify-center">
-      <Text className="text-2xl mb-8 font-bold text-gray-800">Welcome</Text>
-      
-      <Pressable 
-        onPress={() => onOAuthPress(startGoogleOAuthFlow)}
-        className="bg-white px-8 py-3 rounded-full shadow-md mb-4 w-64 flex-row items-center justify-center"
-      >
-        <Text className="text-black font-semibold">Sign in with Google</Text>
-      </Pressable>
-      
-      <Pressable 
-        onPress={() => onOAuthPress(startAppleOAuthFlow)}
-        className="bg-black px-8 py-3 rounded-full shadow-md w-64 flex-row items-center justify-center"
-      >
-        <Text className="text-white font-semibold">Sign in with Apple</Text>
-      </Pressable>
-    </View>
-  )
-}
-
-export default LoginScreen
-*/

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -1,12 +1,14 @@
 import { useRouter } from 'expo-router';
 import React from 'react';
 import { ImageBackground, Pressable, Text, View } from 'react-native';
+import { useAuth } from '@/auth/provider';
 
 const HomeScreen = () => {
+  const { signOut } = useAuth();
   const router = useRouter();
 
-  const handleLogout = () => {
-    console.log('Simulating logout');
+  const handleLogout = async () => {
+    await signOut();
     router.replace('/login');
   };
 
@@ -31,40 +33,3 @@ const HomeScreen = () => {
 };
 
 export default HomeScreen;
-
-// Original Clerk-based code (commented out)
-/*
-import { useAuth } from '@clerk/clerk-expo';
-import { useRouter } from 'expo-router';
-import React from 'react';
-import { Pressable, Text, View } from 'react-native';
-
-const HomeScreen = () => {
-  const { signOut } = useAuth();
-  const router = useRouter();
-
-  const handleLogout = async () => {
-    try {
-      await signOut();
-      router.replace('/login');
-    } catch (error) {
-      console.error('Error signing out:', error);
-    }
-  };
-
-  return (
-    <View className="flex-1 items-center justify-center">
-      <Text className="text-3xl font-bold text-gray-800">Home</Text>
-      
-      <Pressable 
-        onPress={handleLogout}
-        className="absolute bottom-10 bg-red-500 px-8 py-3 rounded-full"
-      >
-        <Text className="text-white font-semibold">Logout</Text>
-      </Pressable>
-    </View>
-  );
-};
-
-export default HomeScreen;
-*/

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,45 +1,19 @@
 import { Slot } from 'expo-router';
 import React from 'react';
 import { ImageBackground, View } from 'react-native';
-
-// Commented out Clerk-related code
-/*
-import { ClerkProvider } from "@clerk/clerk-expo";
-import * as SecureStore from 'expo-secure-store';
-
-const tokenCache = {
-  async getToken(key: string) {
-    try {
-      return SecureStore.getItemAsync(key);
-    } catch (err) {
-      return null;
-    }
-  },
-  async saveToken(key: string, value: string) {
-    try {
-      return SecureStore.setItemAsync(key, value);
-    } catch (err) {
-      return;
-    }
-  },
-};
-*/
+import { AuthProvider } from '@/auth/provider';
 
 export default function RootLayout() {
   return (
-    // Commented out ClerkProvider
-    // <ClerkProvider
-    //   publishableKey={process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!}
-    //   tokenCache={tokenCache}
-    // >
-    <ImageBackground
-      source={require('@assets/images/bg01.png')}
-      className='flex-1'
-      resizeMode='cover'>
-      <View className='flex-1 bg-white/50'>
-        <Slot />
-      </View>
-    </ImageBackground>
-    // </ClerkProvider>
+    <AuthProvider>
+      <ImageBackground
+        source={require('@assets/images/bg01.png')}
+        className='flex-1'
+        resizeMode='cover'>
+        <View className='flex-1 bg-white/50'>
+          <Slot />
+        </View>
+      </ImageBackground>
+    </AuthProvider>
   );
 }

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -2,13 +2,10 @@ import SplashScreenComponent from '@/components/screens/SplashScreen';
 import { useRouter } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import React, { useEffect, useState } from 'react';
-
-// Commented out Clerk import for development
-// import { useAuth } from '@clerk/clerk-expo';
+import { useAuth } from '@/auth/provider';
 
 export default function Home() {
-  // Commented out Clerk authentication for development
-  // const { isLoaded, isSignedIn } = useAuth();
+  const { isLoaded, isSignedIn } = useAuth();
   const router = useRouter();
   const [showSplash, setShowSplash] = useState(true);
 
@@ -31,20 +28,14 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    if (!showSplash) {
-      console.log('Navigating to login screen');
-      router.replace('/login');
-
-      // Original Clerk authentication logic (commented out)
-      /*
-      if (isLoaded && !isSignedIn) {
-        router.replace('/login');
-      } else if (isLoaded && isSignedIn) {
+    if (!showSplash && isLoaded) {
+      if (isSignedIn) {
         router.replace('/(tabs)');
+      } else {
+        router.replace('/login');
       }
-      */
     }
-  }, [showSplash, router]);
+  }, [showSplash, isLoaded, isSignedIn, router]);
 
   if (showSplash) {
     return <SplashScreenComponent />;

--- a/src/auth/provider.tsx
+++ b/src/auth/provider.tsx
@@ -1,0 +1,96 @@
+/* eslint-disable react/display-name */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  ReactNode,
+} from 'react';
+
+let AuthProvider: React.ComponentType<{ children: ReactNode }>;
+let useAuth: () => {
+  isLoaded: boolean;
+  isSignedIn: boolean;
+  signOut: () => void;
+  signIn: () => void;
+};
+let useOAuth: (opts?: { strategy?: string }) => {
+  startOAuthFlow: () => Promise<{ createdSessionId: string | null }>;
+};
+
+if (process.env.EXPO_PUBLIC_USE_CLERK === 'true') {
+  const {
+    ClerkProvider,
+    useAuth: clerkUseAuth,
+    useOAuth: clerkUseOAuth,
+  } = require('@clerk/clerk-expo');
+  const SecureStore = require('expo-secure-store');
+
+  const tokenCache = {
+    async getToken(key: string) {
+      try {
+        return await SecureStore.getItemAsync(key);
+      } catch {
+        return null;
+      }
+    },
+    async saveToken(key: string, value: string) {
+      try {
+        await SecureStore.setItemAsync(key, value);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+
+  AuthProvider = ({ children }: { children: ReactNode }) => (
+    <ClerkProvider
+      publishableKey={process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!}
+      tokenCache={tokenCache}>
+      {children}
+    </ClerkProvider>
+  );
+  (AuthProvider as React.FC).displayName = 'AuthProvider';
+  useAuth = clerkUseAuth;
+  useOAuth = clerkUseOAuth;
+} else {
+  type AuthContextType = {
+    isSignedIn: boolean;
+    signIn: () => void;
+    signOut: () => void;
+  };
+
+  const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+  AuthProvider = ({ children }: { children: ReactNode }) => {
+    const [isSignedIn, setIsSignedIn] = useState(false);
+    const signIn = () => setIsSignedIn(true);
+    const signOut = () => setIsSignedIn(false);
+    return (
+      <AuthContext.Provider value={{ isSignedIn, signIn, signOut }}>
+        {children}
+      </AuthContext.Provider>
+    );
+  };
+  (AuthProvider as React.FC).displayName = 'AuthProvider';
+
+  useAuth = () => {
+    const ctx = useContext(AuthContext);
+    if (!ctx) {
+      throw new Error('useAuth must be used within AuthProvider');
+    }
+    const { isSignedIn, signOut, signIn } = ctx;
+    return { isLoaded: true, isSignedIn, signOut, signIn };
+  };
+
+  useOAuth = () => {
+    const { signIn } = useAuth();
+    const startOAuthFlow = useCallback(async () => {
+      signIn();
+      return { createdSessionId: 'stub-session' };
+    }, [signIn]);
+    return { startOAuthFlow };
+  };
+}
+
+export { AuthProvider, useAuth, useOAuth };


### PR DESCRIPTION
## Summary
- add optional auth provider that wraps Clerk or a local stub
- integrate auth wrapper across app screens
- document `EXPO_PUBLIC_USE_CLERK` flag

## Testing
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_6895f32cf8cc833087a2609069f44a34