### PR TITLE
refactor: add Routine interface and update props

### DIFF
--- a/src/components/ui/RoutineList.tsx
+++ b/src/components/ui/RoutineList.tsx
@@ -3,28 +3,35 @@ import { FlatList, View } from 'react-native';
 import { z } from 'zod';
 import RoutineListItem from './RoutineListItem';
 
+interface Routine {
+  id: number;
+  name: string;
+  type?: string;
+}
+
 const RoutineList: React.FC = () => {
-  const data = [
-    { id: 1, name: 'Routine 1' },
-    { id: 2, name: 'Routine 2' },
-    { id: 3, name: 'Routine 3' },
+  const data: Routine[] = [
+    { id: 1, name: 'Routine 1', type: 'Workout' },
+    { id: 2, name: 'Routine 2', type: 'Meditation' },
+    { id: 3, name: 'Routine 3', type: 'Nutrition' },
     // Add more routine objects as needed
   ];
 
   const routineSchema = z.object({
     id: z.number(),
     name: z.string(),
+    type: z.string().optional(),
   });
 
-  const validatedData = routineSchema.array().parse(data);
+  const validatedData: Routine[] = routineSchema.array().parse(data);
 
-  const renderItem = ({ item }: { item: { id: number; name: string } }) => (
-    <RoutineListItem id={item.id} name={item.name} type={''} />
+  const renderItem = ({ item }: { item: Routine }) => (
+    <RoutineListItem id={item.id} name={item.name} type={item.type} />
   );
 
   return (
     <View>
-      <FlatList
+      <FlatList<Routine>
         data={validatedData}
         renderItem={renderItem}
         keyExtractor={(item) => item.id.toString()}

--- a/src/components/ui/RoutineListItem.tsx
+++ b/src/components/ui/RoutineListItem.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 const RoutineListItemPropsSchema = z.object({
   name: z.string(),
-  type: z.string(),
+  type: z.string().optional(),
   image: z.string().optional(),
   id: z.number(),
   text: z.string().optional(),
@@ -23,7 +23,7 @@ const RoutineListItem: React.FC<RoutineListItemProps> = ({
     <View>
       {image && <Image source={{ uri: image }} />}
       <Text>{name}</Text>
-      <Text>{type}</Text>
+      {type && <Text>{type}</Text>}
       {text && <Text>{text}</Text>}
     </View>
   );


### PR DESCRIPTION
## Summary
- define `Routine` interface with optional type
- apply `Routine` typing to data, `FlatList`, and renderer
- make `RoutineListItem` type prop optional

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_6895fb33dcec8330a942105f58a58f91