### PR TITLE
feat: integrate react-query and auth store

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@clerk/clerk-expo": "^2.2.1",
     "@expo/metro-runtime": "~3.2.3",
     "@expo/vector-icons": "^14.0.1",
+    "@tanstack/react-query": "^5.84.2",
     "@types/react": "~18.2.45",
     "expo": "~51.0.6",
     "expo-av": "~14.0.4",
@@ -48,7 +49,8 @@
     "react-native-svg-transformer": "^1.5.0",
     "react-native-web": "~0.19.10",
     "typescript": "~5.3.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,19 +1,23 @@
 import { Slot } from 'expo-router';
 import React from 'react';
 import { ImageBackground, View } from 'react-native';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@/lib/queryClient';
 import { AuthProvider } from '@features/auth/provider';
 
 export default function RootLayout() {
   return (
-    <AuthProvider>
-      <ImageBackground
-        source={require('@assets/images/bg01.png')}
-        className='flex-1'
-        resizeMode='cover'>
-        <View className='flex-1 bg-white/50'>
-          <Slot />
-        </View>
-      </ImageBackground>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <ImageBackground
+          source={require('@assets/images/bg01.png')}
+          className='flex-1'
+          resizeMode='cover'>
+          <View className='flex-1 bg-white/50'>
+            <Slot />
+          </View>
+        </ImageBackground>
+      </AuthProvider>
+    </QueryClientProvider>
   );
 }

--- a/src/features/auth/provider.tsx
+++ b/src/features/auth/provider.tsx
@@ -1,11 +1,6 @@
 /* eslint-disable react/display-name */
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useState,
-  ReactNode,
-} from 'react';
+import React, { useCallback, ReactNode } from 'react';
+import { useAuthStore } from './store';
 
 let AuthProvider: React.ComponentType<{ children: ReactNode }>;
 let useAuth: () => {
@@ -54,33 +49,12 @@ if (process.env.EXPO_PUBLIC_USE_CLERK === 'true') {
   useAuth = clerkUseAuth;
   useOAuth = clerkUseOAuth;
 } else {
-  type AuthContextType = {
-    isSignedIn: boolean;
-    signIn: () => void;
-    signOut: () => void;
-  };
-
-  const AuthContext = createContext<AuthContextType | undefined>(undefined);
-
-  AuthProvider = ({ children }: { children: ReactNode }) => {
-    const [isSignedIn, setIsSignedIn] = useState(false);
-    const signIn = () => setIsSignedIn(true);
-    const signOut = () => setIsSignedIn(false);
-    return (
-      <AuthContext.Provider value={{ isSignedIn, signIn, signOut }}>
-        {children}
-      </AuthContext.Provider>
-    );
-  };
+  AuthProvider = ({ children }: { children: ReactNode }) => <>{children}</>;
   (AuthProvider as React.FC).displayName = 'AuthProvider';
 
   useAuth = () => {
-    const ctx = useContext(AuthContext);
-    if (!ctx) {
-      throw new Error('useAuth must be used within AuthProvider');
-    }
-    const { isSignedIn, signOut, signIn } = ctx;
-    return { isLoaded: true, isSignedIn, signOut, signIn };
+    const { isSignedIn, signIn, signOut } = useAuthStore();
+    return { isLoaded: true, isSignedIn, signIn, signOut };
   };
 
   useOAuth = () => {

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  isSignedIn: boolean;
+  signIn: () => void;
+  signOut: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isSignedIn: false,
+  signIn: () => set({ isSignedIn: true }),
+  signOut: () => set({ isSignedIn: false }),
+}));

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5,
+      refetchOnWindowFocus: false,
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- install zustand and @tanstack/react-query
- provide configured QueryClient and wrap root layout
- manage auth with a zustand store instead of local state

## Testing
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_68960ad543508330a99ed67444bcd1dc