### PR TITLE
chore: add pre-commit linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@clerk/clerk-expo": "^2.2.1",
@@ -61,8 +62,10 @@
     "eslint-config-expo": "^7.1.2",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-expo": "^51.0.4",
+    "lint-staged": "^16.1.5",
     "prettier": "^3.3.3",
     "react-test-renderer": "18.2.0",
     "tailwindcss": "3.3.2"
@@ -70,5 +73,11 @@
   "overrides": {
     "@expo/config-plugins": "~8.0.0"
   },
-  "private": true
+  "private": true,
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint",
+      "prettier --check"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- add husky pre-commit hook running lint-staged
- run eslint and prettier on staged files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896127fd6748330816baa80e56041ab