### PR TITLE
feat: centralize theme tokens

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,21 +1,22 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Tabs } from 'expo-router';
 import React from 'react';
+import { colors } from '@/theme';
 
 export default function TabsLayout() {
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: '#3b82f6', // Tailwind blue-500
-        tabBarInactiveTintColor: '#6b7280', // Tailwind gray-500
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.gray500,
         tabBarStyle: {
-          backgroundColor: 'rgba(255, 255, 255, 0.7)', // Semi-transparent white
+          backgroundColor: colors.white70,
         },
         headerStyle: {
-          backgroundColor: 'transparent', // Make header transparent
+          backgroundColor: 'transparent',
         },
-        headerTransparent: true, // This ensures the header is truly transparent
-        headerTintColor: '#000000', // Black text for better visibility
+        headerTransparent: true,
+        headerTintColor: colors.black,
       }}>
       <Tabs.Screen
         name='index'

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'expo-router';
 import React from 'react';
 import { ImageBackground, Pressable, Text, View } from 'react-native';
 import { useAuth } from '@features/auth/provider';
+import { colors } from '@/theme';
 
 const HomeScreen = () => {
   const { signOut } = useAuth();
@@ -17,7 +18,7 @@ const HomeScreen = () => {
       source={require('@assets/images/bg01.png')}
       style={{ flex: 1, width: '100%', height: '100%' }}
       resizeMode='cover'>
-      <View style={{ flex: 1, backgroundColor: 'rgba(255, 255, 255, 0.5)' }}>
+      <View style={{ flex: 1, backgroundColor: colors.white50 }}>
         <View className='flex-1 items-center justify-center'>
           <Text className='text-3xl font-bold text-gray-800'>Home</Text>
 

--- a/src/components/screens/SplashScreen.tsx
+++ b/src/components/screens/SplashScreen.tsx
@@ -3,6 +3,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import React, { useEffect } from 'react';
 import { ImageBackground, Text, View } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { colors } from '@/theme';
 
 const AnimatedText = Animated.createAnimatedComponent(Text);
 
@@ -40,7 +41,7 @@ const SplashScreenComponent = () => {
               style={[
                 letterStyles[index],
                 {
-                  textShadowColor: 'rgba(0, 0, 0, 0.8)',
+                  textShadowColor: colors.black80,
                   textShadowOffset: { width: 3, height: 3 },
                   textShadowRadius: 4,
                 },
@@ -53,7 +54,7 @@ const SplashScreenComponent = () => {
         <Text
           className='bg-orange-200 rounded-md p-2 text-4xl font-bold text-blue-500'
           style={{
-            textShadowColor: 'rgba(0, 0, 0, 0.75)',
+            textShadowColor: colors.black75,
             textShadowOffset: { width: 2, height: 2 },
             textShadowRadius: 3,
           }}>

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,0 +1,24 @@
+const colors = {
+  primary: '#3b82f6',
+  gray500: '#6b7280',
+  black: '#000000',
+  white: '#ffffff',
+  white70: 'rgba(255, 255, 255, 0.7)',
+  white50: 'rgba(255, 255, 255, 0.5)',
+  black80: 'rgba(0, 0, 0, 0.8)',
+  black75: 'rgba(0, 0, 0, 0.75)',
+};
+
+const fontSizes = {
+  xs: 12,
+  sm: 14,
+  base: 16,
+  lg: 18,
+  xl: 20,
+  '2xl': 24,
+  '3xl': 30,
+  '4xl': 36,
+  '5xl': 48,
+};
+
+module.exports = { colors, fontSizes };

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,24 @@
+export const colors = {
+  primary: '#3b82f6', // Tailwind blue-500
+  gray500: '#6b7280', // Tailwind gray-500
+  black: '#000000',
+  white: '#ffffff',
+  white70: 'rgba(255, 255, 255, 0.7)',
+  white50: 'rgba(255, 255, 255, 0.5)',
+  black80: 'rgba(0, 0, 0, 0.8)',
+  black75: 'rgba(0, 0, 0, 0.75)',
+};
+
+export const fontSizes = {
+  xs: 12,
+  sm: 14,
+  base: 16,
+  lg: 18,
+  xl: 20,
+  '2xl': 24,
+  '3xl': 30,
+  '4xl': 36,
+  '5xl': 48,
+};
+
+export default { colors, fontSizes };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const { colors, fontSizes } = require('./src/theme');
+
 module.exports = {
   content: [
     './src/app/**/*.{js,jsx,ts,tsx}',
@@ -5,6 +7,8 @@ module.exports = {
   ],
   theme: {
     extend: {
+      colors,
+      fontSize: fontSizes,
       fontFamily: {
         rmono: ['Roboto-Mono', 'sans-serif'],
       },


### PR DESCRIPTION
## Summary
- create centralized theme module exporting color and font scales
- extend Tailwind to consume theme tokens
- replace hard-coded colors in tabs layout, home screen, and splash screen with theme variables

## Testing
- `npm test`
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_68961bf459548330a655b144efbbddb7