### PR TITLE
docs: add roadmap file with milestone table

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,3 @@ eas build
 ## Roadmap
 
 See [ROADMAP.md](ROADMAP.md) for upcoming milestones and their status.
-

--- a/README.md
+++ b/README.md
@@ -72,10 +72,5 @@ eas build
 
 ## Roadmap
 
-- Detailed card tab for symbol-based communication
-- Grid navigation with search
-- Asset store and card list management
-- Routine flow tab for daily schedules
-- Multilingual support
-- Error boundaries and enhanced validation with Zod
-- React Query for caching and data management
+See [ROADMAP.md](ROADMAP.md) for upcoming milestones and their status.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # Roadmap
 
+<!-- prettier-ignore -->
 | Phase | Milestone | Status | Issue | Description |
-|-------|-----------|--------|-------|-------------|
-| 1 | Symbol card tab | Planned | [#1](../../issues/1) | Detailed card tab for symbol-based communication. |
-| 2 | Grid search navigation | Planned | [#2](../../issues/2) | Quickly find symbols via search-driven grid navigation. |
+| ----- | --------- | ------ | ----- | ----------- |
+| 1 | Symbol card tab | Planned | [#1](../../issues/1) | Card tab for symbol-based communication. |
+| 2 | Grid search navigation | Planned | [#2](../../issues/2) | Search-driven grid for quick symbol lookup. |
 | 3 | Asset store & card list | Planned | [#3](../../issues/3) | Manage downloadable assets and card collections. |
-| 4 | Routine flow tab | Planned | [#4](../../issues/4) | Support daily schedules with a dedicated routine flow tab. |
+| 4 | Routine flow tab | Planned | [#4](../../issues/4) | Dedicated routine-flow tab for daily schedules. |
 | 5 | Multilingual support | Planned | [#5](../../issues/5) | Localize the app for multiple languages. |
-| 6 | Error boundaries & Zod validation | Planned | [#6](../../issues/6) | Improve stability with error boundaries and schema validation. |
-| 7 | React Query integration | Planned | [#7](../../issues/7) | Add React Query for caching and remote data management. |
-
+| 6 | Error boundaries & Zod validation | Planned | [#6](../../issues/6) | Add error boundaries and schema checks. |
+| 7 | React Query integration | Planned | [#7](../../issues/7) | Use React Query for caching and remote data. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,12 @@
+# Roadmap
+
+| Phase | Milestone | Status | Issue | Description |
+|-------|-----------|--------|-------|-------------|
+| 1 | Symbol card tab | Planned | [#1](../../issues/1) | Detailed card tab for symbol-based communication. |
+| 2 | Grid search navigation | Planned | [#2](../../issues/2) | Quickly find symbols via search-driven grid navigation. |
+| 3 | Asset store & card list | Planned | [#3](../../issues/3) | Manage downloadable assets and card collections. |
+| 4 | Routine flow tab | Planned | [#4](../../issues/4) | Support daily schedules with a dedicated routine flow tab. |
+| 5 | Multilingual support | Planned | [#5](../../issues/5) | Localize the app for multiple languages. |
+| 6 | Error boundaries & Zod validation | Planned | [#6](../../issues/6) | Improve stability with error boundaries and schema validation. |
+| 7 | React Query integration | Planned | [#7](../../issues/7) | Add React Query for caching and remote data management. |
+


### PR DESCRIPTION
## Summary
- move roadmap content into dedicated `ROADMAP.md` with phases, statuses, descriptions, and issue links
- simplify `README.md` to link to the new roadmap

## Testing
- `npm test`
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_689635f29c90833088385f529472748a