### PR TITLE
feat: add magenta color and use in animation

### DIFF
--- a/src/hooks/useLetterAnimation.ts
+++ b/src/hooks/useLetterAnimation.ts
@@ -1,4 +1,5 @@
 import { RAINBOW_COLORS } from '@/constants/colors';
+import { colors } from '@/theme';
 import { useEffect } from 'react';
 import {
   Easing,
@@ -41,7 +42,7 @@ export const useLetterAnimation = (index: number) => {
       [RAINBOW_COLORS[colorIndex], RAINBOW_COLORS[nextColorIndex]]
     );
     return {
-      color: index === 3 ? '#FF00FF' : color, // Keep 'N' magenta
+      color: index === 3 ? colors.magenta : color, // Keep 'N' magenta
       transform: [{ translateY: yOffset.value }],
     };
   });

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -7,6 +7,7 @@ export const colors = {
   white50: 'rgba(255, 255, 255, 0.5)',
   black80: 'rgba(0, 0, 0, 0.8)',
   black75: 'rgba(0, 0, 0, 0.75)',
+  magenta: '#ff00ff',
 };
 
 export const fontSizes = {


### PR DESCRIPTION
## Summary
- add `magenta` to theme colors
- use `colors.magenta` in letter animation

## Testing
- `npm test`
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_689643b0a45483308805a0e54bcdc371