### PR TITLE
feat: add Sentry initializer module

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,14 +1,12 @@
 import { Slot } from 'expo-router';
-import * as Sentry from 'sentry-expo';
 import React from 'react';
 import { ImageBackground, View } from 'react-native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
+import { initSentry } from '@/lib/sentry';
 import { AuthProvider } from '@features/auth/provider';
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-});
+initSentry();
 
 export default function RootLayout() {
   return (

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,9 @@
+import * as Sentry from 'sentry-expo';
+
+export function initSentry() {
+  if (process.env.SENTRY_DSN && process.env.NODE_ENV !== 'development') {
+    Sentry.init({
+      dsn: process.env.SENTRY_DSN,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add Sentry initializer that respects environment settings
- use initializer in app layout

## Testing
- `npm test`
- `npm run lint`
- `npm run ts:check`


------
https://chatgpt.com/codex/tasks/task_e_689645d2c14483308f1c55fd2a753863