### PR TITLE
feat: add error boundaries and zod validation

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -2,31 +2,34 @@ import { Ionicons } from '@expo/vector-icons';
 import { Tabs } from 'expo-router';
 import React from 'react';
 import { colors } from '@/theme';
+import ErrorBoundary from '@/components/ErrorBoundary';
 
 export default function TabsLayout() {
   return (
-    <Tabs
-      screenOptions={{
-        tabBarActiveTintColor: colors.primary,
-        tabBarInactiveTintColor: colors.gray500,
-        tabBarStyle: {
-          backgroundColor: colors.white70,
-        },
-        headerStyle: {
-          backgroundColor: 'transparent',
-        },
-        headerTransparent: true,
-        headerTintColor: colors.black,
-      }}>
-      <Tabs.Screen
-        name='index'
-        options={{
-          title: 'Home',
-          tabBarIcon: ({ color, size }) => (
-            <Ionicons name='home' size={size} color={color} />
-          ),
-        }}
-      />
-    </Tabs>
+    <ErrorBoundary>
+      <Tabs
+        screenOptions={{
+          tabBarActiveTintColor: colors.primary,
+          tabBarInactiveTintColor: colors.gray500,
+          tabBarStyle: {
+            backgroundColor: colors.white70,
+          },
+          headerStyle: {
+            backgroundColor: 'transparent',
+          },
+          headerTransparent: true,
+          headerTintColor: colors.black,
+        }}>
+        <Tabs.Screen
+          name='index'
+          options={{
+            title: 'Home',
+            tabBarIcon: ({ color, size }) => (
+              <Ionicons name='home' size={size} color={color} />
+            ),
+          }}
+        />
+      </Tabs>
+    </ErrorBoundary>
   );
 }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { initSentry } from '@/lib/sentry';
 import { AuthProvider } from '@features/auth/provider';
+import ErrorBoundary from '@/components/ErrorBoundary';
 
 initSentry();
 
@@ -17,7 +18,9 @@ export default function RootLayout() {
           className='flex-1'
           resizeMode='cover'>
           <View className='flex-1 bg-white/50'>
-            <Slot />
+            <ErrorBoundary>
+              <Slot />
+            </ErrorBoundary>
           </View>
         </ImageBackground>
       </AuthProvider>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // You could log error information here or report to an error tracking service
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View className='flex-1 items-center justify-center p-4'>
+          <Text className='text-red-500 font-bold mb-2'>
+            Something went wrong.
+          </Text>
+          {this.state.error && (
+            <Text className='text-gray-700'>{this.state.error.message}</Text>
+          )}
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/features/routines/api.ts
+++ b/src/features/routines/api.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const routineSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  type: z.string().optional(),
+  image: z.string().optional(),
+  text: z.string().optional(),
+});
+
+export const routinesResponseSchema = z.array(routineSchema);
+
+export type Routine = z.infer<typeof routineSchema>;
+
+export async function fetchRoutines(): Promise<Routine[]> {
+  const response = await fetch('https://example.com/api/routines');
+  const data = await response.json();
+  return routinesResponseSchema.parse(data);
+}

--- a/src/features/routines/components/molecules/RoutineListItem.tsx
+++ b/src/features/routines/components/molecules/RoutineListItem.tsx
@@ -12,13 +12,10 @@ const RoutineListItemPropsSchema = z.object({
 
 type RoutineListItemProps = z.infer<typeof RoutineListItemPropsSchema>;
 
-const RoutineListItem: React.FC<RoutineListItemProps> = ({
-  name,
-  type,
-  image,
-  id,
-  text,
-}) => {
+const RoutineListItem: React.FC<RoutineListItemProps> = (props) => {
+  const { name, type, image, id, text } =
+    RoutineListItemPropsSchema.parse(props);
+
   return (
     <View>
       {image && <Image source={{ uri: image }} />}

--- a/src/features/routines/components/organisms/RoutineList.tsx
+++ b/src/features/routines/components/organisms/RoutineList.tsx
@@ -1,38 +1,45 @@
 import React from 'react';
-import { FlatList, View } from 'react-native';
-import { z } from 'zod';
+import { FlatList, Text, View } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
 import RoutineListItem from '../molecules/RoutineListItem';
-
-interface Routine {
-  id: number;
-  name: string;
-  type?: string;
-}
+import { fetchRoutines, Routine } from '../../api';
 
 const RoutineList: React.FC = () => {
-  const data: Routine[] = [
-    { id: 1, name: 'Routine 1', type: 'Workout' },
-    { id: 2, name: 'Routine 2', type: 'Meditation' },
-    { id: 3, name: 'Routine 3', type: 'Nutrition' },
-    // Add more routine objects as needed
-  ];
-
-  const routineSchema = z.object({
-    id: z.number(),
-    name: z.string(),
-    type: z.string().optional(),
+  const { data, error, isLoading } = useQuery<Routine[]>({
+    queryKey: ['routines'],
+    queryFn: fetchRoutines,
   });
 
-  const validatedData: Routine[] = routineSchema.array().parse(data);
+  if (isLoading) {
+    return (
+      <View>
+        <Text>Loading...</Text>
+      </View>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <View>
+        <Text>Failed to load routines.</Text>
+      </View>
+    );
+  }
 
   const renderItem = ({ item }: { item: Routine }) => (
-    <RoutineListItem id={item.id} name={item.name} type={item.type} />
+    <RoutineListItem
+      id={item.id}
+      name={item.name}
+      type={item.type}
+      image={item.image}
+      text={item.text}
+    />
   );
 
   return (
     <View>
       <FlatList<Routine>
-        data={validatedData}
+        data={data}
         renderItem={renderItem}
         keyExtractor={(item) => item.id.toString()}
       />


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component and wrap core layouts
- validate routine API responses and component props with Zod
- fetch routines with React Query and schema validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896761d710c8330818e609da65a2f15