### PR TITLE
feat: add react-query hooks for routines

### DIFF
--- a/src/features/routines/api.ts
+++ b/src/features/routines/api.ts
@@ -1,3 +1,4 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
 export const routineSchema = z.object({
@@ -12,8 +13,43 @@ export const routinesResponseSchema = z.array(routineSchema);
 
 export type Routine = z.infer<typeof routineSchema>;
 
-export async function fetchRoutines(): Promise<Routine[]> {
+const ROUTINES_QUERY_KEY = ['routines'];
+
+async function fetchRoutines(): Promise<Routine[]> {
   const response = await fetch('https://example.com/api/routines');
   const data = await response.json();
   return routinesResponseSchema.parse(data);
 }
+
+async function createRoutine(
+  newRoutine: Omit<Routine, 'id'>
+): Promise<Routine> {
+  const response = await fetch('https://example.com/api/routines', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(newRoutine),
+  });
+  const data = await response.json();
+  return routineSchema.parse(data);
+}
+
+export function useRoutines() {
+  return useQuery<Routine[]>({
+    queryKey: ROUTINES_QUERY_KEY,
+    queryFn: fetchRoutines,
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useCreateRoutine() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createRoutine,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ROUTINES_QUERY_KEY });
+    },
+  });
+}
+
+export { ROUTINES_QUERY_KEY };

--- a/src/features/routines/components/organisms/RoutineList.tsx
+++ b/src/features/routines/components/organisms/RoutineList.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import { FlatList, Text, View } from 'react-native';
-import { useQuery } from '@tanstack/react-query';
 import RoutineListItem from '../molecules/RoutineListItem';
-import { fetchRoutines, Routine } from '../../api';
+import { Routine, useRoutines } from '../../api';
 
 const RoutineList: React.FC = () => {
-  const { data, error, isLoading } = useQuery<Routine[]>({
-    queryKey: ['routines'],
-    queryFn: fetchRoutines,
-  });
+  const { data, error, isLoading } = useRoutines();
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- add custom `useRoutines` and `useCreateRoutine` hooks backed by React Query
- update `RoutineList` to consume shared routines query

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68967aa5421883308af40cc6c91b6401